### PR TITLE
Tests unitarios del Backend y corrección de permisos

### DIFF
--- a/Backend/pedagogia/tests.py
+++ b/Backend/pedagogia/tests.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+from .models import Categoria, Asignatura, Recurso
+
+User = get_user_model()
+
+class RecursoViewSetTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username='author_test',
+            email='author@test.com',
+            password='Password123!',
+            rol='asesor'
+        )
+        self.categoria = Categoria.objects.create(nombre='Test Categoria')
+        self.asignatura = Asignatura.objects.create(nombre='Test Asignatura')
+
+    def test_create_recurso_automatically_assigns_user(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            'titulo': 'Nuevo Recurso de Test',
+            'categoria': self.categoria.id,
+            'asignatura': self.asignatura.id,
+            'contenido': '<p>Hola</p>',
+            'tipo': 'video'
+        }
+        response = self.client.post('/api/pedagogia/recursos/', payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Verificar en base de datos
+        recurso = Recurso.objects.get(id=response.data['id'])
+        self.assertEqual(recurso.creado_por, self.user)
+        self.assertEqual(recurso.titulo, 'Nuevo Recurso de Test')
+
+    def test_list_recursos(self):
+        Recurso.objects.create(
+            titulo='Recurso 1',
+            categoria=self.categoria,
+            asignatura=self.asignatura,
+            creado_por=self.user
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/pedagogia/recursos/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['titulo'], 'Recurso 1')
+
+    def test_unauthenticated_cannot_access_recursos(self):
+        response = self.client.get('/api/pedagogia/recursos/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/Backend/users/permissions.py
+++ b/Backend/users/permissions.py
@@ -11,7 +11,9 @@ class IsAdminOrOwner(permissions.BasePermission):
         # Solo administradores pueden crear usuarios (POST)
         if request.method == 'POST':
             return request.user and request.user.is_staff
-        # Para listar o ver, cualquier autenticado pasa (el filtro de object entra después)
+        # Solo administradores pueden listar a todos
+        if getattr(view, 'action', '') == 'list':
+            return request.user and request.user.is_staff
         return request.user and request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):

--- a/Backend/users/tests.py
+++ b/Backend/users/tests.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+
+User = get_user_model()
+
+class UserViewSetTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin_user = User.objects.create_superuser(
+            username='admin_test',
+            email='admin@test.com',
+            password='Admin1234!'
+        )
+        self.normal_user = User.objects.create_user(
+            username='user_test',
+            email='user@test.com',
+            password='User1234!',
+            rol='asesor'
+        )
+
+    def test_admin_can_list_users(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_normal_user_cannot_list_users(self):
+        self.client.force_authenticate(user=self.normal_user)
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_cannot_list_users(self):
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
Se agregaron tests automáticos para los endpoints de Usuarios y Recursos en Django. Se corrigió un error en los permisos donde usuarios no-admin podían listar todos los usuarios. Closes #39