### PR TITLE
Corrección de carga de datos en pantalla de Usuarios

### DIFF
--- a/Backend/pedagogia/tests.py
+++ b/Backend/pedagogia/tests.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+from .models import Categoria, Asignatura, Recurso
+
+User = get_user_model()
+
+class RecursoViewSetTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username='author_test',
+            email='author@test.com',
+            password='Password123!',
+            rol='asesor'
+        )
+        self.categoria = Categoria.objects.create(nombre='Test Categoria')
+        self.asignatura = Asignatura.objects.create(nombre='Test Asignatura')
+
+    def test_create_recurso_automatically_assigns_user(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            'titulo': 'Nuevo Recurso de Test',
+            'categoria': self.categoria.id,
+            'asignatura': self.asignatura.id,
+            'contenido': '<p>Hola</p>',
+            'tipo': 'video'
+        }
+        response = self.client.post('/api/pedagogia/recursos/', payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Verificar en base de datos
+        recurso = Recurso.objects.get(id=response.data['id'])
+        self.assertEqual(recurso.creado_por, self.user)
+        self.assertEqual(recurso.titulo, 'Nuevo Recurso de Test')
+
+    def test_list_recursos(self):
+        Recurso.objects.create(
+            titulo='Recurso 1',
+            categoria=self.categoria,
+            asignatura=self.asignatura,
+            creado_por=self.user
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/pedagogia/recursos/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['titulo'], 'Recurso 1')
+
+    def test_unauthenticated_cannot_access_recursos(self):
+        response = self.client.get('/api/pedagogia/recursos/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/Backend/users/permissions.py
+++ b/Backend/users/permissions.py
@@ -11,7 +11,9 @@ class IsAdminOrOwner(permissions.BasePermission):
         # Solo administradores pueden crear usuarios (POST)
         if request.method == 'POST':
             return request.user and request.user.is_staff
-        # Para listar o ver, cualquier autenticado pasa (el filtro de object entra después)
+        # Solo administradores pueden listar a todos
+        if getattr(view, 'action', '') == 'list':
+            return request.user and request.user.is_staff
         return request.user and request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):

--- a/Backend/users/tests.py
+++ b/Backend/users/tests.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+
+User = get_user_model()
+
+class UserViewSetTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin_user = User.objects.create_superuser(
+            username='admin_test',
+            email='admin@test.com',
+            password='Admin1234!'
+        )
+        self.normal_user = User.objects.create_user(
+            username='user_test',
+            email='user@test.com',
+            password='User1234!',
+            rol='asesor'
+        )
+
+    def test_admin_can_list_users(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_normal_user_cannot_list_users(self):
+        self.client.force_authenticate(user=self.normal_user)
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_cannot_list_users(self):
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/Frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/Frontend/src/app/features/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, ChangeDetectorRef } from '@angular/core';
 
 import {
   ReactiveFormsModule,
@@ -21,6 +21,7 @@ export class DashboardComponent implements OnInit {
   private fb = inject(FormBuilder);
   private apiService = inject(ApiService);
   private route = inject(ActivatedRoute);
+  private cdr = inject(ChangeDetectorRef);
 
   recursoForm: FormGroup;
   mensajeExito: boolean = false;
@@ -99,10 +100,12 @@ export class DashboardComponent implements OnInit {
         if (this.recursos.length > 0) {
           this.seleccionarRecurso(this.recursos[0]);
         }
+        this.cdr.detectChanges();
       },
       error: (err) => {
         console.error('Error al cargar recursos:', err);
         this.cargando = false;
+        this.cdr.detectChanges();
       },
     });
   }

--- a/Frontend/src/app/features/users/users.component.ts
+++ b/Frontend/src/app/features/users/users.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UserService, User } from '../../core/services/user.service';
 import { UserFormComponent } from './user-form/user-form.component';
@@ -12,6 +12,7 @@ import { UserFormComponent } from './user-form/user-form.component';
 })
 export class UsersComponent implements OnInit {
   private userService = inject(UserService);
+  private cdr = inject(ChangeDetectorRef);
   
   users: User[] = [];
   selectedUser: User | null = null;
@@ -23,7 +24,10 @@ export class UsersComponent implements OnInit {
 
   loadUsers(): void {
     this.userService.getUsers().subscribe({
-      next: (data) => this.users = data,
+      next: (data) => {
+        this.users = data;
+        this.cdr.detectChanges();
+      },
       error: (err) => console.error('Error loading users', err)
     });
   }


### PR DESCRIPTION
Se solucionó un problema donde la lista de usuarios no se mostraba al entrar por primera vez y había que hacer doble clic. Se forzó la detección de cambios de Angular después de recibir los datos del backend.