### PR TITLE
feature/issue 41 qa forms

### DIFF
--- a/Frontend/src/app/features/dashboard/dashboard.component.html
+++ b/Frontend/src/app/features/dashboard/dashboard.component.html
@@ -152,7 +152,8 @@
             <span class="material-symbols-outlined text-outline">filter_list</span>
             <label class="font-bold text-label-md">Filtrar por Asignatura:</label>
             <select
-              [(ngModel)]="filtroMateria"
+              [value]="filtroMateria"
+              (change)="onFiltroMateriaChange($event)"
               class="border dark:bg-[#2d2d2d] dark:border-outline px-md py-1 rounded cursor-pointer"
             >
               <option value="Todas">Todas las materias</option>
@@ -299,14 +300,16 @@
                   <label class="text-sm font-bold block mb-1">Color Principal (Tokens)</label>
                   <input
                     type="color"
-                    [(ngModel)]="configElemento.color"
+                    [value]="configElemento.color"
+                    (input)="onColorChange($event)"
                     class="w-full h-10 border border-outline cursor-pointer rounded p-1 dark:bg-[#2d2d2d]"
                   />
                 </div>
                 <div class="flex items-center gap-2">
                   <input
                     type="checkbox"
-                    [(ngModel)]="configElemento.mostrarIcono"
+                    [checked]="configElemento.mostrarIcono"
+                    (change)="onMostrarIconoChange($event)"
                     class="cursor-pointer h-4 w-4 text-primary focus:ring-primary rounded"
                   />
                   <label class="text-sm font-bold cursor-pointer">Mostrar íconos visuales</label>

--- a/Frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/Frontend/src/app/features/dashboard/dashboard.component.ts
@@ -5,7 +5,6 @@ import {
   FormBuilder,
   FormGroup,
   Validators,
-  FormsModule,
 } from '@angular/forms';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { ApiService } from '../../core/services/api.service';
@@ -13,7 +12,7 @@ import { ApiService } from '../../core/services/api.service';
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [ReactiveFormsModule, FormsModule, RouterModule],
+  imports: [ReactiveFormsModule, RouterModule],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.css',
 })
@@ -285,6 +284,18 @@ export class DashboardComponent implements OnInit {
   }
   rehacer() {
     alert('Rehacer acción (Mock)');
+  }
+
+  onFiltroMateriaChange(event: Event) {
+    this.filtroMateria = (event.target as HTMLSelectElement).value;
+  }
+
+  onColorChange(event: Event) {
+    this.configElemento.color = (event.target as HTMLInputElement).value;
+  }
+
+  onMostrarIconoChange(event: Event) {
+    this.configElemento.mostrarIcono = (event.target as HTMLInputElement).checked;
   }
 
   cerrarSesion() {

--- a/Frontend/src/app/features/login/login.component.html
+++ b/Frontend/src/app/features/login/login.component.html
@@ -39,7 +39,7 @@
     <div
       class="bg-surface-container-lowest border border-outline-variant p-lg rounded-lg shadow-sm"
     >
-      <form class="space-y-md" (submit)="$event.preventDefault()">
+      <form [formGroup]="loginForm" class="space-y-md" (submit)="$event.preventDefault()">
         <!-- Username Input -->
         <div class="space-y-xs">
           <label class="text-label-lg font-label-lg text-on-surface" for="username"
@@ -56,11 +56,13 @@
               id="username"
               placeholder="ej. admin"
               type="text"
-              [(ngModel)]="username"
-              name="username"
+              formControlName="username"
               autocomplete="username"
             />
           </div>
+          @if (loginForm.get('username')?.hasError('required') && loginForm.get('username')?.touched) {
+            <p class="text-red-600 text-xs mt-1">Este campo es obligatorio</p>
+          }
         </div>
 
         <!-- Password Input -->
@@ -79,8 +81,7 @@
               id="password"
               placeholder="••••••••"
               [type]="showPassword ? 'text' : 'password'"
-              [(ngModel)]="password"
-              name="password"
+              formControlName="password"
               autocomplete="current-password"
             />
             <button
@@ -93,6 +94,12 @@
               }}</span>
             </button>
           </div>
+          @if (loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched) {
+            <p class="text-red-600 text-xs mt-1">Este campo es obligatorio</p>
+          }
+          @if (loginForm.get('password')?.hasError('minlength') && loginForm.get('password')?.touched) {
+            <p class="text-red-600 text-xs mt-1">La contraseña debe tener al menos 6 caracteres</p>
+          }
         </div>
 
         <!-- Forgot Password Link -->

--- a/Frontend/src/app/features/login/login.component.ts
+++ b/Frontend/src/app/features/login/login.component.ts
@@ -1,12 +1,12 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [FormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './login.component.html',
   host: {
     class: 'w-full flex flex-grow',
@@ -16,9 +16,13 @@ export class LoginComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
+  private fb = inject(FormBuilder);
 
-  username = '';
-  password = '';
+  loginForm = this.fb.group({
+    username: ['', [Validators.required]],
+    password: ['', [Validators.required, Validators.minLength(6)]]
+  });
+
   errorMsg = '';
   showPassword = false;
 
@@ -35,12 +39,14 @@ export class LoginComponent implements OnInit {
   login() {
     this.errorMsg = '';
 
-    if (!this.username.trim() || !this.password.trim()) {
-      this.errorMsg = 'Por favor completá usuario y contraseña.';
+    if (this.loginForm.invalid) {
+      this.loginForm.markAllAsTouched();
       return;
     }
 
-    this.authService.login(this.username, this.password).subscribe({
+    const { username, password } = this.loginForm.value;
+
+    this.authService.login(username!, password!).subscribe({
       next: () => {
         this.router.navigate(['/home']);
       },

--- a/Frontend/src/app/features/users/user-form/user-form.component.html
+++ b/Frontend/src/app/features/users/user-form/user-form.component.html
@@ -5,7 +5,7 @@
       <label class="form-label">Nombre de Usuario</label>
       <input type="text" class="form-control" formControlName="username">
       <div *ngIf="userForm.get('username')?.invalid && userForm.get('username')?.touched" class="text-danger mt-1">
-        El nombre de usuario es requerido.
+        El nombre de usuario es obligatorio
       </div>
     </div>
 
@@ -13,7 +13,8 @@
       <label class="form-label">Email</label>
       <input type="email" class="form-control" formControlName="email">
       <div *ngIf="userForm.get('email')?.invalid && userForm.get('email')?.touched" class="text-danger mt-1">
-        El email es requerido y debe tener formato válido. (CA-14)
+        <span *ngIf="userForm.get('email')?.hasError('required')">El email es requerido.</span>
+        <span *ngIf="userForm.get('email')?.hasError('email')">Ingrese un email válido.</span>
       </div>
     </div>
 


### PR DESCRIPTION
## Resumen
Se resuelve la **Issue #41** eliminando `FormsModule` (`ngModel`) del proyecto para usar únicamente **Reactive Forms**, evitando la mezcla de paradigmas en los formularios del frontend.

## Cambios
- **Login:** Migrado a Reactive Forms con validaciones (`required` en ambos campos y `minLength(6)` en password) y mensajes de error en rojo.
- **Dashboard:** Removidos los `ngModel` del filtro, selector de color y checkbox; reemplazados por bindings de propiedad y eventos nativos (`change`/`input`).
- **Formulario de Usuarios:** Añadido feedback visual para formato de email inválido, usuario requerido y deshabilitación del botón de guardar si el formulario tiene errores.
